### PR TITLE
feature: add async command state context

### DIFF
--- a/packages/viewlet-registry/src/parts/IViewletRegistry/IViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/IViewletRegistry/IViewletRegistry.ts
@@ -12,6 +12,19 @@ export interface WrappedLoadContent {
   (uid: number, ...args: readonly any[]): any
 }
 
+export interface StateUpdater<T> {
+  (state: T): T
+}
+
+export interface AsyncCommandContext<T> {
+  readonly getState: () => T
+  readonly updateState: (updater: StateUpdater<T>) => Promise<T>
+}
+
+export interface AsyncCommand<T> {
+  (context: AsyncCommandContext<T>, ...args: readonly any[]): Promise<void>
+}
+
 export interface LoadContentResult<T> {
   readonly error: undefined
   readonly state: T
@@ -42,6 +55,7 @@ export interface IViewletRegistry<T> {
   readonly getKeys: () => readonly number[]
   readonly registerCommands: (commandMap: any) => void
   readonly set: (uid: number, oldState: T, newState: T, scheduledState?: T) => void
+  readonly wrapAsyncCommand: (fn: AsyncCommand<T>) => WrappedFn
   readonly wrapCommand: (fn: Fn<T>) => WrappedFn
   readonly wrapGetter: (fn: Getter<T>) => WrappedGetter
   readonly wrapLoadContent: (fn: LoadContentFunction<T>) => WrappedLoadContent

--- a/packages/viewlet-registry/src/parts/Main/Main.ts
+++ b/packages/viewlet-registry/src/parts/Main/Main.ts
@@ -1,1 +1,2 @@
+export type { AsyncCommand, AsyncCommandContext, StateUpdater } from '../IViewletRegistry/IViewletRegistry.ts'
 export * from '../ViewletRegistry/ViewletRegistry.ts'

--- a/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
@@ -1,8 +1,11 @@
 import type {
+  AsyncCommand,
+  AsyncCommandContext,
   DiffModule,
   Fn,
   IViewletRegistry,
   LoadContentFunction,
+  StateUpdater,
   WrappedFn,
   WrappedLoadContent,
 } from '../IViewletRegistry/IViewletRegistry.ts'
@@ -16,6 +19,20 @@ const toCommandId = (key: string): string => {
 export const create = <T>(): IViewletRegistry<T> => {
   const states: Record<number | string, StateTuple<T>> = Object.create(null)
   const commandMapRef = {}
+
+  const updateState = (uid: number, updater: StateUpdater<T>): Promise<T> => {
+    const current = states[uid]
+    const updatedState = updater(current.newState)
+    if (updatedState !== current.newState) {
+      states[uid] = {
+        newState: updatedState,
+        oldState: current.oldState,
+        scheduledState: updatedState,
+      }
+    }
+    return Promise.resolve(updatedState)
+  }
+
   return {
     clear(): void {
       for (const key of Object.keys(states)) {
@@ -52,6 +69,16 @@ export const create = <T>(): IViewletRegistry<T> => {
     },
     set(uid, oldState: T, newState: T, scheduledState?: T): void {
       states[uid] = { newState, oldState, scheduledState: scheduledState ?? newState }
+    },
+    wrapAsyncCommand(fn: AsyncCommand<T>): WrappedFn {
+      const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
+        const context: AsyncCommandContext<T> = {
+          getState: () => states[uid].newState,
+          updateState: (updater) => updateState(uid, updater),
+        }
+        await fn(context, ...args)
+      }
+      return wrapped
     },
     wrapCommand(fn: Fn<T>): WrappedFn {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {

--- a/packages/viewlet-registry/test/ViewletRegistry.test.ts
+++ b/packages/viewlet-registry/test/ViewletRegistry.test.ts
@@ -1,6 +1,100 @@
 import { expect, test } from '@jest/globals'
 import * as ViewletRegistry from '../src/parts/ViewletRegistry/ViewletRegistry.ts'
 
-test('create', async () => {
+interface TestState {
+  readonly count: number
+  readonly values: readonly string[]
+}
+
+const createState = (): TestState => ({
+  count: 0,
+  values: [],
+})
+
+test('create', () => {
   expect(ViewletRegistry.create).toBeDefined()
+})
+
+test('wrapAsyncCommand should update state', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const command = registry.wrapAsyncCommand(async (context, count: number) => {
+    await context.updateState((latestState) => ({
+      ...latestState,
+      count,
+    }))
+  })
+
+  await command(1, 42)
+
+  expect(registry.get(1).newState).toEqual({
+    count: 42,
+    values: [],
+  })
+})
+
+test('wrapAsyncCommand should apply updates to the latest state', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: firstCommandStarted, resolve: notifyFirstCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForSecondCommand, resolve: continueFirstCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapAsyncCommand(async (context, value: string) => {
+    if (value === 'first') {
+      notifyFirstCommandStarted()
+      await waitForSecondCommand
+    }
+    await context.updateState((latestState) => ({
+      ...latestState,
+      values: [...latestState.values, value],
+    }))
+  })
+
+  const firstCommand = command(1, 'first')
+  await firstCommandStarted
+  await command(1, 'second')
+  continueFirstCommand()
+  await firstCommand
+
+  expect(registry.get(1).newState.values).toEqual(['second', 'first'])
+})
+
+test('wrapAsyncCommand getState should return the latest state', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const command = registry.wrapAsyncCommand(async (context) => {
+    await context.updateState((latestState) => ({
+      ...latestState,
+      count: latestState.count + 1,
+    }))
+    expect(context.getState().count).toBe(1)
+  })
+
+  await command(1)
+})
+
+test('wrapAsyncCommand should preserve the current state when the updater returns it', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const command = registry.wrapAsyncCommand(async (context) => {
+    await context.updateState((latestState) => latestState)
+  })
+
+  await command(1)
+
+  expect(registry.get(1).newState).toBe(state)
+})
+
+test('wrapAsyncCommand should propagate command errors', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const command = registry.wrapAsyncCommand(async () => {
+    throw new Error('command failed')
+  })
+
+  await expect(command(1)).rejects.toThrow('command failed')
 })


### PR DESCRIPTION
Adds an opt-in async command wrapper with a state context. Async handlers can commit reducer-based updates against the latest registered state, preventing stale snapshots from overwriting concurrent changes.