### PR TITLE
fix: isolate async commands by view lifecycle

### DIFF
--- a/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
@@ -17,10 +17,20 @@ const toCommandId = (key: string): string => {
 }
 
 export const create = <T>(): IViewletRegistry<T> => {
+  const generations: Record<number | string, number> = Object.create(null)
   const states: Record<number | string, StateTuple<T>> = Object.create(null)
   const commandMapRef = {}
 
-  const updateState = (uid: number, updater: StateUpdater<T>): Promise<T> => {
+  const getGeneration = (uid: number): number => generations[uid] || 0
+
+  const isCurrentGeneration = (uid: number, generation: number): boolean => {
+    return states[uid] !== undefined && getGeneration(uid) === generation
+  }
+
+  const updateState = (uid: number, generation: number, fallbackState: T, updater: StateUpdater<T>): Promise<T> => {
+    if (!isCurrentGeneration(uid, generation)) {
+      return Promise.resolve(fallbackState)
+    }
     const current = states[uid]
     const updatedState = updater(current.newState)
     if (updatedState !== current.newState) {
@@ -68,13 +78,27 @@ export const create = <T>(): IViewletRegistry<T> => {
       Object.assign(commandMapRef, commandMap)
     },
     set(uid, oldState: T, newState: T, scheduledState?: T): void {
+      const current = states[uid]
+      if (!current || (oldState === newState && newState !== current.newState)) {
+        generations[uid] = getGeneration(uid) + 1
+      }
       states[uid] = { newState, oldState, scheduledState: scheduledState ?? newState }
     },
     wrapAsyncCommand(fn: AsyncCommand<T>): WrappedFn {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
+        const generation = getGeneration(uid)
+        let latestState = states[uid].newState
         const context: AsyncCommandContext<T> = {
-          getState: () => states[uid].newState,
-          updateState: (updater) => updateState(uid, updater),
+          getState: () => {
+            if (isCurrentGeneration(uid, generation)) {
+              latestState = states[uid].newState
+            }
+            return latestState
+          },
+          updateState: async (updater) => {
+            latestState = await updateState(uid, generation, latestState, updater)
+            return latestState
+          },
         }
         await fn(context, ...args)
       }
@@ -82,9 +106,13 @@ export const create = <T>(): IViewletRegistry<T> => {
     },
     wrapCommand(fn: Fn<T>): WrappedFn {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
+        const generation = getGeneration(uid)
         const { newState, oldState } = states[uid]
         const newerState = await fn(newState, ...args)
         if (oldState === newerState || newState === newerState) {
+          return
+        }
+        if (!isCurrentGeneration(uid, generation)) {
           return
         }
         const latestOld = states[uid]
@@ -106,10 +134,16 @@ export const create = <T>(): IViewletRegistry<T> => {
     },
     wrapLoadContent(fn: LoadContentFunction<T>): WrappedLoadContent {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<any> => {
+        const generation = getGeneration(uid)
         const { newState, oldState } = states[uid]
         const result = await fn(newState, ...args)
         const { error, state } = result
         if (oldState === state || newState === state) {
+          return {
+            error,
+          }
+        }
+        if (!isCurrentGeneration(uid, generation)) {
           return {
             error,
           }

--- a/packages/viewlet-registry/test/ViewletRegistry.test.ts
+++ b/packages/viewlet-registry/test/ViewletRegistry.test.ts
@@ -88,6 +88,59 @@ test('wrapAsyncCommand should preserve the current state when the updater return
   expect(registry.get(1).newState).toBe(state)
 })
 
+test('wrapAsyncCommand should not update a replacement view with the same uid', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: commandStarted, resolve: notifyCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForReplacement, resolve: continueCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapAsyncCommand(async (context) => {
+    notifyCommandStarted()
+    await waitForReplacement
+    await context.updateState((latestState) => ({
+      ...latestState,
+      count: 42,
+    }))
+  })
+
+  const pendingCommand = command(1)
+  await commandStarted
+  const replacementState: TestState = {
+    count: 1,
+    values: ['replacement'],
+  }
+  registry.set(1, replacementState, replacementState)
+  continueCommand()
+  await pendingCommand
+
+  expect(registry.get(1).newState).toBe(replacementState)
+})
+
+test('wrapAsyncCommand should continue after the current view is rendered', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: commandStarted, resolve: notifyCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForRender, resolve: continueCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapAsyncCommand(async (context) => {
+    notifyCommandStarted()
+    await waitForRender
+    await context.updateState((latestState) => ({
+      ...latestState,
+      count: 42,
+    }))
+  })
+
+  const pendingCommand = command(1)
+  await commandStarted
+  const currentState = registry.get(1).newState
+  registry.set(1, currentState, currentState)
+  continueCommand()
+  await pendingCommand
+
+  expect(registry.get(1).newState.count).toBe(42)
+})
+
 test('wrapAsyncCommand should propagate command errors', async () => {
   const registry = ViewletRegistry.create<TestState>()
   const state = createState()


### PR DESCRIPTION
Prevent late async command results from updating a replacement view that reuses the same uid. Preserve normal updates across render commits and apply the lifecycle guard to all asynchronous wrappers.