### PR TITLE
feature: serialize state commands

### DIFF
--- a/packages/viewlet-registry/src/parts/IViewletRegistry/IViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/IViewletRegistry/IViewletRegistry.ts
@@ -59,4 +59,5 @@ export interface IViewletRegistry<T> {
   readonly wrapCommand: (fn: Fn<T>) => WrappedFn
   readonly wrapGetter: (fn: Getter<T>) => WrappedGetter
   readonly wrapLoadContent: (fn: LoadContentFunction<T>) => WrappedLoadContent
+  readonly wrapSerialCommand: (fn: Fn<T>) => WrappedFn
 }

--- a/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
@@ -17,6 +17,7 @@ const toCommandId = (key: string): string => {
 }
 
 export const create = <T>(): IViewletRegistry<T> => {
+  const commandQueues = new Map<number, Promise<void>>()
   const generations: Record<number | string, number> = Object.create(null)
   const states: Record<number | string, StateTuple<T>> = Object.create(null)
   const commandMapRef = {}
@@ -45,6 +46,7 @@ export const create = <T>(): IViewletRegistry<T> => {
 
   return {
     clear(): void {
+      commandQueues.clear()
       for (const key of Object.keys(states)) {
         delete states[key]
       }
@@ -61,6 +63,7 @@ export const create = <T>(): IViewletRegistry<T> => {
       return diffResult
     },
     dispose(uid: number): void {
+      commandQueues.delete(uid)
       delete states[uid]
     },
     get(uid: number): StateTuple<T> {
@@ -157,6 +160,47 @@ export const create = <T>(): IViewletRegistry<T> => {
         }
         return {
           error,
+        }
+      }
+      return wrapped
+    },
+    wrapSerialCommand(fn: Fn<T>): WrappedFn {
+      const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
+        const generation = getGeneration(uid)
+        const previous = commandQueues.get(uid) || Promise.resolve()
+        const run = async (): Promise<void> => {
+          try {
+            await previous
+          } catch {
+            // The previous caller receives its error; later commands must still run.
+          }
+          if (!isCurrentGeneration(uid, generation)) {
+            return
+          }
+          const { newState, oldState } = states[uid]
+          const newerState = await fn(newState, ...args)
+          if (oldState === newerState || newState === newerState) {
+            return
+          }
+          if (!isCurrentGeneration(uid, generation)) {
+            return
+          }
+          const latestOld = states[uid]
+          const latestNew = { ...latestOld.newState, ...newerState }
+          states[uid] = {
+            newState: latestNew,
+            oldState: latestOld.oldState,
+            scheduledState: latestNew,
+          }
+        }
+        const current = run()
+        commandQueues.set(uid, current)
+        try {
+          await current
+        } finally {
+          if (commandQueues.get(uid) === current) {
+            commandQueues.delete(uid)
+          }
         }
       }
       return wrapped

--- a/packages/viewlet-registry/test/ViewletRegistry.test.ts
+++ b/packages/viewlet-registry/test/ViewletRegistry.test.ts
@@ -151,3 +151,82 @@ test('wrapAsyncCommand should propagate command errors', async () => {
 
   await expect(command(1)).rejects.toThrow('command failed')
 })
+
+test('wrapSerialCommand should run commands in invocation order', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: firstCommandStarted, resolve: notifyFirstCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForFirstCommand, resolve: continueFirstCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapSerialCommand(async (currentState, value: string) => {
+    if (value === 'first') {
+      notifyFirstCommandStarted()
+      await waitForFirstCommand
+    }
+    return {
+      ...currentState,
+      values: [...currentState.values, value],
+    }
+  })
+
+  const firstCommand = command(1, 'first')
+  await firstCommandStarted
+  const secondCommand = command(1, 'second')
+  continueFirstCommand()
+  await Promise.all([firstCommand, secondCommand])
+
+  expect(registry.get(1).newState.values).toEqual(['first', 'second'])
+})
+
+test('wrapSerialCommand should continue the queue after a command error', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const command = registry.wrapSerialCommand(async (currentState, value: string) => {
+    if (value === 'first') {
+      throw new Error('command failed')
+    }
+    return {
+      ...currentState,
+      values: [...currentState.values, value],
+    }
+  })
+
+  const firstCommand = command(1, 'first')
+  const secondCommand = command(1, 'second')
+  await expect(firstCommand).rejects.toThrow('command failed')
+  await secondCommand
+
+  expect(registry.get(1).newState.values).toEqual(['second'])
+})
+
+test('wrapSerialCommand should not run queued commands for a replacement view', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: firstCommandStarted, resolve: notifyFirstCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForReplacement, resolve: continueFirstCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapSerialCommand(async (currentState, value: string) => {
+    if (value === 'first') {
+      notifyFirstCommandStarted()
+      await waitForReplacement
+    }
+    return {
+      ...currentState,
+      values: [...currentState.values, value],
+    }
+  })
+
+  const firstCommand = command(1, 'first')
+  await firstCommandStarted
+  const secondCommand = command(1, 'second')
+  const replacementState: TestState = {
+    count: 1,
+    values: ['replacement'],
+  }
+  registry.set(1, replacementState, replacementState)
+  continueFirstCommand()
+  await Promise.all([firstCommand, secondCommand])
+
+  expect(registry.get(1).newState).toBe(replacementState)
+})


### PR DESCRIPTION
Adds a per-view serialized command wrapper for ordered asynchronous state transactions. Queued commands survive earlier errors and are isolated from replacement view lifecycles.