### PR TITLE
fix: bind queued commands when execution starts

### DIFF
--- a/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
@@ -166,7 +166,6 @@ export const create = <T>(): IViewletRegistry<T> => {
     },
     wrapSerialCommand(fn: Fn<T>): WrappedFn {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
-        const generation = getGeneration(uid)
         const previous = commandQueues.get(uid) || Promise.resolve()
         const run = async (): Promise<void> => {
           try {
@@ -174,9 +173,10 @@ export const create = <T>(): IViewletRegistry<T> => {
           } catch {
             // The previous caller receives its error; later commands must still run.
           }
-          if (!isCurrentGeneration(uid, generation)) {
+          if (!states[uid]) {
             return
           }
+          const generation = getGeneration(uid)
           const { newState, oldState } = states[uid]
           const newerState = await fn(newState, ...args)
           if (oldState === newerState || newState === newerState) {

--- a/packages/viewlet-registry/test/ViewletRegistry.test.ts
+++ b/packages/viewlet-registry/test/ViewletRegistry.test.ts
@@ -200,7 +200,7 @@ test('wrapSerialCommand should continue the queue after a command error', async 
   expect(registry.get(1).newState.values).toEqual(['second'])
 })
 
-test('wrapSerialCommand should not run queued commands for a replacement view', async () => {
+test('wrapSerialCommand should run queued commands against the current view lifecycle', async () => {
   const registry = ViewletRegistry.create<TestState>()
   const state = createState()
   registry.set(1, state, state)
@@ -228,5 +228,8 @@ test('wrapSerialCommand should not run queued commands for a replacement view', 
   continueFirstCommand()
   await Promise.all([firstCommand, secondCommand])
 
-  expect(registry.get(1).newState).toBe(replacementState)
+  expect(registry.get(1).newState).toEqual({
+    count: 1,
+    values: ['replacement', 'second'],
+  })
 })


### PR DESCRIPTION
Binds queued commands to the active view lifecycle when their execution begins. Running stale commands remain isolated, while commands queued during a view replacement execute against the replacement state.