### PR TITLE
feature: add serial async command context

### DIFF
--- a/packages/viewlet-registry/src/parts/IViewletRegistry/IViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/IViewletRegistry/IViewletRegistry.ts
@@ -59,5 +59,6 @@ export interface IViewletRegistry<T> {
   readonly wrapCommand: (fn: Fn<T>) => WrappedFn
   readonly wrapGetter: (fn: Getter<T>) => WrappedGetter
   readonly wrapLoadContent: (fn: LoadContentFunction<T>) => WrappedLoadContent
+  readonly wrapSerialAsyncCommand: (fn: AsyncCommand<T>) => WrappedFn
   readonly wrapSerialCommand: (fn: Fn<T>) => WrappedFn
 }

--- a/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
+++ b/packages/viewlet-registry/src/parts/ViewletRegistry/ViewletRegistry.ts
@@ -44,6 +44,43 @@ export const create = <T>(): IViewletRegistry<T> => {
     return Promise.resolve(updatedState)
   }
 
+  const createAsyncCommandContext = (uid: number, generation: number): AsyncCommandContext<T> => {
+    let latestState = states[uid].newState
+    return {
+      getState: (): T => {
+        if (isCurrentGeneration(uid, generation)) {
+          latestState = states[uid].newState
+        }
+        return latestState
+      },
+      updateState: async (updater): Promise<T> => {
+        latestState = await updateState(uid, generation, latestState, updater)
+        return latestState
+      },
+    }
+  }
+
+  const enqueueCommand = async (uid: number, command: () => Promise<void>): Promise<void> => {
+    const previous = commandQueues.get(uid) || Promise.resolve()
+    const run = async (): Promise<void> => {
+      try {
+        await previous
+      } catch {
+        // The previous caller receives its error; later commands must still run.
+      }
+      await command()
+    }
+    const current = run()
+    commandQueues.set(uid, current)
+    try {
+      await current
+    } finally {
+      if (commandQueues.get(uid) === current) {
+        commandQueues.delete(uid)
+      }
+    }
+  }
+
   return {
     clear(): void {
       commandQueues.clear()
@@ -90,19 +127,7 @@ export const create = <T>(): IViewletRegistry<T> => {
     wrapAsyncCommand(fn: AsyncCommand<T>): WrappedFn {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
         const generation = getGeneration(uid)
-        let latestState = states[uid].newState
-        const context: AsyncCommandContext<T> = {
-          getState: () => {
-            if (isCurrentGeneration(uid, generation)) {
-              latestState = states[uid].newState
-            }
-            return latestState
-          },
-          updateState: async (updater) => {
-            latestState = await updateState(uid, generation, latestState, updater)
-            return latestState
-          },
-        }
+        const context = createAsyncCommandContext(uid, generation)
         await fn(context, ...args)
       }
       return wrapped
@@ -164,15 +189,22 @@ export const create = <T>(): IViewletRegistry<T> => {
       }
       return wrapped
     },
+    wrapSerialAsyncCommand(fn: AsyncCommand<T>): WrappedFn {
+      const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
+        await enqueueCommand(uid, async () => {
+          if (!states[uid]) {
+            return
+          }
+          const generation = getGeneration(uid)
+          const context = createAsyncCommandContext(uid, generation)
+          await fn(context, ...args)
+        })
+      }
+      return wrapped
+    },
     wrapSerialCommand(fn: Fn<T>): WrappedFn {
       const wrapped = async (uid: number, ...args: readonly any[]): Promise<void> => {
-        const previous = commandQueues.get(uid) || Promise.resolve()
-        const run = async (): Promise<void> => {
-          try {
-            await previous
-          } catch {
-            // The previous caller receives its error; later commands must still run.
-          }
+        await enqueueCommand(uid, async () => {
           if (!states[uid]) {
             return
           }
@@ -192,16 +224,7 @@ export const create = <T>(): IViewletRegistry<T> => {
             oldState: latestOld.oldState,
             scheduledState: latestNew,
           }
-        }
-        const current = run()
-        commandQueues.set(uid, current)
-        try {
-          await current
-        } finally {
-          if (commandQueues.get(uid) === current) {
-            commandQueues.delete(uid)
-          }
-        }
+        })
       }
       return wrapped
     },

--- a/packages/viewlet-registry/test/ViewletRegistry.test.ts
+++ b/packages/viewlet-registry/test/ViewletRegistry.test.ts
@@ -233,3 +233,67 @@ test('wrapSerialCommand should run queued commands against the current view life
     values: ['replacement', 'second'],
   })
 })
+
+test('wrapSerialAsyncCommand should preserve invocation order and the rendered state baseline', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: firstCommandStarted, resolve: notifyFirstCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForFirstCommand, resolve: continueFirstCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapSerialAsyncCommand(async (context, value: string) => {
+    if (value === 'first') {
+      notifyFirstCommandStarted()
+      await waitForFirstCommand
+    }
+    await context.updateState((currentState) => ({
+      ...currentState,
+      values: [...currentState.values, value],
+    }))
+  })
+
+  const firstCommand = command(1, 'first')
+  await firstCommandStarted
+  const secondCommand = command(1, 'second')
+  continueFirstCommand()
+  await Promise.all([firstCommand, secondCommand])
+
+  expect(registry.get(1)).toEqual({
+    newState: {
+      count: 0,
+      values: ['first', 'second'],
+    },
+    oldState: state,
+    scheduledState: {
+      count: 0,
+      values: ['first', 'second'],
+    },
+  })
+})
+
+test('wrapSerialAsyncCommand should isolate running updates from a replacement view', async () => {
+  const registry = ViewletRegistry.create<TestState>()
+  const state = createState()
+  registry.set(1, state, state)
+  const { promise: commandStarted, resolve: notifyCommandStarted } = Promise.withResolvers<void>()
+  const { promise: waitForReplacement, resolve: continueCommand } = Promise.withResolvers<void>()
+  const command = registry.wrapSerialAsyncCommand(async (context) => {
+    notifyCommandStarted()
+    await waitForReplacement
+    await context.updateState((currentState) => ({
+      ...currentState,
+      count: 42,
+    }))
+  })
+
+  const pendingCommand = command(1)
+  await commandStarted
+  const replacementState: TestState = {
+    count: 1,
+    values: ['replacement'],
+  }
+  registry.set(1, replacementState, replacementState)
+  continueCommand()
+  await pendingCommand
+
+  expect(registry.get(1).newState).toBe(replacementState)
+})


### PR DESCRIPTION
Adds a lifecycle-safe async state context that shares the per-view command queue. This lets long-running commands commit intermediate reducer updates without advancing the last-rendered baseline or losing invocation order.